### PR TITLE
response correction

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -82,7 +82,7 @@ A successful request will be prompted with either `200 - Success` or `204 - No C
 Sadly, sometimes requests to the API are not successful. Failures can occur for a wide range of reasons. In all cases, the API returns an HTTP Status Code that indicates the nature of the failure (below), with a response body in JSON format containing additional information.
 
 * 200   `Success` - If a resource was requested, it will be available at the top level of the response body.
-* 201   `Created` -  The request was successful and a resource was created. The Location Header field indicates the URI the resource can be found.
+* 201   `Created` -  The request was successful and a resource was created.
 * 204   `No Content` - The request was successful and the body intentionally contains no data.
 
 * 400   `Bad request` - This occurs when the request was not sent according to the documentation. Can be either the JSON format or the content. Check the documentation and the syntax of your request and try again.
@@ -229,10 +229,6 @@ A kitchen is a place with cooking, food processing and storage devices where foo
 
 + Response 201 (application/json)
 
-    + Headers
-
-            Location: https://co2.eaternity.ch/api/kitchens/198764
-
     + Body
 
             {   "kitchen": {
@@ -282,10 +278,6 @@ Update or create the kitchen with the specific id
         }
 
 + Response 201 (application/json)
-
-    + Headers
-
-            Location: https://co2.eaternity.ch/api/kitchens/198764
 
     + Body
 
@@ -416,10 +408,6 @@ Create a recipe resource and receive the CO₂-Value and Eaternity Award. Exampl
         }
 
 + Response 200 (application/json)
-
-    + Headers
-
-            Location: https://co2.eaternity.ch/api/recipes/d1ed2263-b1b2-4f50-9e9d-ba62cae81f29
 
     + Body
 
@@ -736,10 +724,6 @@ Create a recipe resource in a specific kitchen and receive the CO₂-Value and E
         }
 
 + Response 200 (application/json)
-ed
-    + Headers
-
-            Location: https://co2.eaternity.ch/api/kitchens/45674/recipes/d1ed2263-b1b2-4f50-9e9d-ba62cae81f29
 
     + Body
 
@@ -976,10 +960,6 @@ Update or create a certain recipe with this id. The whole recipe resource with a
 
 + Response 200 (application/json)
 
-    + Headers
-
-            Location: https://co2.eaternity.ch/api/kitchens/45674/recipes/d1ed2263-b1b2-4f50-9e9d-ba62cae81f29
-
     + Body
 
             {
@@ -1200,10 +1180,6 @@ Create a supply without specifying an id. If the request is sent with `full-reso
 
 + Response 200 (application/json)
 
-    + Headers
-
-        Location: https://co2.eaternity.ch/api/kitchens/1987647/supplies/d1ed2263
-
     + Body
 
     {
@@ -1307,9 +1283,7 @@ Update or create this supply with the specific id. The supply always needs to ha
         }
 
 + Response 200 (application/json)
-    + Headers
 
-        Location: https://co2.eaternity.ch/api/kitchens/1987647/supplies/d1ed2263
     + Body
 
     {


### PR DESCRIPTION
I have removed the location header from the "Created" responses (because it's not used, and doesn't really work, as discussed).

After reviewing the document, I think maybe it's not necessary to add the version of the supply response for the "full-resource=true&indicators=true" version of the POST /kitchens/{kitchen_id}/supplies/ 

The correct response would simply be a copy/paste of the response to the GET /kitchens/{kitchen_id}/supplies/{supply_id}?indicators=true call just below it. Since the description of the post version says "If the request is sent with `full-resource=true`, then a complete response will be given, the same as the response to the GET command below." I think that's probably sufficient.